### PR TITLE
Improve profile validation and HTML reporting

### DIFF
--- a/PySystem/config/profiles/default.json
+++ b/PySystem/config/profiles/default.json
@@ -1,12 +1,12 @@
 {
   "obj_dirs": [
-    "/Project/fpx_auto/",
-    "/Project/PySystem/"
+    "/path/to/fpx_auto/",
+    "/path/to/PySystem/"
   ],
-  "tc_base": "/Project/fpx_auto/trail",
-  "sce_root": "/Project/fpx_auto",
+  "tc_base": "/path/to/fpx_auto/trail",
+  "sce_root": "/path/to/fpx_auto",
   "node_list": ["Linux111", "Linux101"],
-  "lab_dir": "/Project/fpx_auto/environment",
+  "lab_dir": "/path/to/fpx_auto/environment",
   "log_dir": "logs",
   "Xauthority": "/root/.Xauthority",
   "Webdriver_dir": "/opt/Webdriver/bin"

--- a/PySystem/config/profiles/office.json
+++ b/PySystem/config/profiles/office.json
@@ -1,12 +1,12 @@
 {
   "obj_dirs": [
-    "/Project/fpx_auto/",
-    "/Project/PySystem/"
+    "/path/to/fpx_auto/",
+    "/path/to/PySystem/"
   ],
-  "tc_base": "/Project/office/trail",
-  "sce_root": "/Project/office",
+  "tc_base": "/path/to/office/trail",
+  "sce_root": "/path/to/office",
   "node_list": ["Linux105"],
-  "lab_dir": "/Project/office/environment",
+  "lab_dir": "/path/to/office/environment",
   "log_dir": "logs",
   "Xauthority": "/root/.Xauthority",
   "Webdriver_dir": "/opt/Webdriver/bin"

--- a/PySystem/report/default.css
+++ b/PySystem/report/default.css
@@ -70,6 +70,14 @@ span.test_summary_warn {
 }
 
 span.test_summary_erro {
-	color:#ff0000;
+        color:#ff0000;
+}
+
+pre.tc-stack {
+        margin-left:20px;
+        background:#f9f9f9;
+        border:1px solid #ccc;
+        padding:4px;
+        white-space:pre-wrap;
 }
 

--- a/PySystem/report/template.html
+++ b/PySystem/report/template.html
@@ -10,7 +10,11 @@
     <A href="#" onClick="collapseTree('root');return false;">Collapse All</A>&nbsp;&nbsp;&nbsp;
     <a>STATUS:</a>
     <a id="running_status" status="INIT">INIT</a>
-    <span id="summary"></span>
+    <span id="summary">
+      <span class="test_summary_pass">Pass: 0</span>
+      <span class="test_summary_erro"> Fail: 0</span>
+      <span class="test_summary_warn"> Warn: 0</span>
+    </span>
     <br><br>
     <span id="hierarchy" class="test_report_pass">Scenario Hierarchy:<br></span>
     <UL CLASS="mktree" id="root">

--- a/PySystem/report/update.js
+++ b/PySystem/report/update.js
@@ -83,4 +83,27 @@ function updateStatus() {
   document.getElementById("curr_tc").innerHTML = runFlag + curr_title;
 }
 
+function toggleStack(ev) {
+  var a = ev.target;
+  if (a.tagName !== 'A' || !a.classList.contains('tc-link')) {
+    return;
+  }
+  var stack = a.getAttribute('stack');
+  if (!stack) {
+    return;
+  }
+  ev.preventDefault();
+  var next = a.nextSibling;
+  if (next && next.classList && next.classList.contains('tc-stack')) {
+    next.remove();
+    return;
+  }
+  var pre = document.createElement('pre');
+  pre.className = 'tc-stack';
+  pre.textContent = stack;
+  a.parentNode.insertBefore(pre, a.nextSibling);
+}
+
+document.addEventListener('click', toggleStack);
+
 initEventSource();

--- a/PySystem/sysrunner/run.py
+++ b/PySystem/sysrunner/run.py
@@ -109,13 +109,20 @@ def main():
         conf: dict = json.load(f)
         assert len(conf) > 0
 
+    REQUIRED_PROFILE_FIELDS = [
+        'obj_dirs', 'tc_base', 'sce_root', 'node_list',
+        'lab_dir', 'log_dir', 'Xauthority', 'Webdriver_dir'
+    ]
     if args.profile:
         prof_path = os.path.join(pysys_root, 'config', 'profiles', f'{args.profile}.json')
-        if os.path.isfile(prof_path):
-            with open(prof_path, 'r') as f:
-                conf.update(json.load(f))
-        else:
+        if not os.path.isfile(prof_path):
             raise FileNotFoundError(f'Profile {args.profile} not found: {prof_path}')
+        with open(prof_path, 'r') as f:
+            prof_conf = json.load(f)
+        missing = [k for k in REQUIRED_PROFILE_FIELDS if k not in prof_conf]
+        if missing:
+            raise KeyError(f'Profile {args.profile} missing required keys: {", ".join(missing)}')
+        conf.update(prof_conf)
 
     conf_file = args.conf
     if conf_file:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ cp PySystem/config/config_sample.yaml PySystem/config/config_local.yaml
 
 # 2) pick or edit a runtime profile
 cp PySystem/config/profiles/default.json PySystem/config/profiles/my.json
-#    edit fields such as node_list or sce_root as needed
+#    edit fields such as `node_list` or `sce_root` as needed.  All
+#    profiles must define the keys listed below.
 
 # 3) run one scenario
 python PySystem/sysrunner/run.py --profile=my Policy-Matching/Explicit-L7/10001
@@ -45,6 +46,14 @@ fields can be overridden with an additional level such as
 | `sce_root` | Location of scenarios (CSV files)    |
 | `node_list`| Names of nodes defined in YAML config|
 | `log_dir`  | Directory under `tc_base` for logs   |
+| `obj_dirs` | Additional Python module locations    |
+| `lab_dir`  | Path to lab environment modules       |
+| `Xauthority` | X11 auth file for GUI tests         |
+| `Webdriver_dir` | Directory containing WebDriver binaries |
+
+The bundled profiles use example paths such as `/path/to/fpx_auto/`. These
+should be replaced with real locations on your system. If any of the
+required keys are missing at runtime `run.py` will exit with an error.
 
 ## 🏃 Running Tests
 


### PR DESCRIPTION
## Summary
- add clearer instructions for editing profiles in README
- provide placeholder paths in sample profiles
- validate required profile keys in `run.py`
- show pass/fail/warn summary in scenario.html
- launch SSE server from ReportHtml and allow showing stack trace on click

## Testing
- `python -m py_compile PySystem/sysrunner/run.py PySystem/SystemTestCase/sys_suite.py PySystem/SystemTestCase/SysTestCase.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pexpect')*

------
https://chatgpt.com/codex/tasks/task_e_6843722be45c8330a9be63aedb3f4fbf